### PR TITLE
「インストール方法」の細部の修正。

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Ubuntu系のディストリで、パッケージのアップデートをする�
 ```
 https://github.com/PlasmaLinux/pacup
 cd pacup
-sudo install_pacup.sh
+sudo bash install_pacup.sh
 ```


### PR DESCRIPTION
`sudo install_pacup.sh`を実行すると`sudo: install_pacup.sh: command not found`となってしまうので、`sudo bash install_pacup.sh`に修正しました。
反映お願いします。